### PR TITLE
Increased max decoded protobuf message size

### DIFF
--- a/src/lib/consumer/updates.rs
+++ b/src/lib/consumer/updates.rs
@@ -39,7 +39,12 @@ pub struct UpdatesSourceImpl {
 
 pub async fn new(blockchain_updates_url: &str) -> Result<UpdatesSourceImpl> {
     Ok(UpdatesSourceImpl {
-        grpc_client: BlockchainUpdatesApiClient::connect(blockchain_updates_url.to_owned()).await?,
+        grpc_client: {
+            const MAX_MSG_SIZE: usize = 8 * 1024 * 1024; // 8 MB instead of the default 4 MB
+            BlockchainUpdatesApiClient::connect(blockchain_updates_url.to_owned())
+                .await?
+                .max_decoding_message_size(MAX_MSG_SIZE)
+        },
     })
 }
 


### PR DESCRIPTION
After tonic update there is a limit on a message being decoded - 4 MB, this is not enough for our needs. Increased to 8 MB.